### PR TITLE
to remove large space after first comment

### DIFF
--- a/app/assets/stylesheets/active_admin_sidebar.scss
+++ b/app/assets/stylesheets/active_admin_sidebar.scss
@@ -85,3 +85,7 @@ body.active_admin.index #active_admin_content.with_sidebar.collapsible_sidebar {
     margin-right: 0;
   }
 }
+
+.with_sidebar .comments .active_admin_comment {
+  overflow: auto;
+}


### PR DESCRIPTION
<img width="1055" alt="Screenshot 2020-10-12 at 16 06 17" src="https://user-images.githubusercontent.com/10907664/95750220-7b239a00-0ca5-11eb-9635-39eb0b3bbe0e.png">
