### PR TITLE
drop ruby 2.4, add ruby2.5 to travis instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,5 @@ env:
     - RAILS=6.0.0 AA=2.8.0
 
 rvm:
-  - 2.4
+  - 2.5
   - 2.6
-
-jobs:
-  exclude:
-    - rvm: 2.4
-      env: RAILS=5.2.2 AA=2.8.0
-    - rvm: 2.4
-      env: RAILS=6.0.0 AA=2.8.0


### PR DESCRIPTION
Ruby 2.4
status: eol
release date: 2016-12-25
EOL date: 2020-03-31