### PR TITLE
Add NPM module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Gem Version](https://badge.fury.io/rb/active_admin_sidebar.svg)](https://badge.fury.io/rb/active_admin_sidebar)
+[![NPM Version](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_sidebar.svg)](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_sidebar)
+![npm](https://img.shields.io/npm/dm/@activeadmin-plugins/active_admin_sidebar)
+
 # ActiveAdmin Sidebar
 
 Provides ability to manipulate sidebar position for ActiveAdmin (tested with ActiveAdmin ~> 1.0.0)
@@ -10,6 +14,7 @@ Add following line to the `Gemfile`
 gem 'active_admin_sidebar'
 ```
 
+##### Using assets via Sprockets
 Add following line to the `app/assets/stylesheets/active_admin.css.scss`
 
 ```scss
@@ -23,6 +28,39 @@ If you want to use collapsing feature, add following line
 ```
 
 to the `app/assets/javascripts/active_admin.js`
+
+##### Using assets via Webpacker (or any other assets bundler) as a NPM module (Yarn package)
+
+Execute:
+
+    $ npm i @activeadmin-plugins/active_admin_sidebar
+
+Or
+
+    $ yarn add @activeadmin-plugins/active_admin_sidebar
+
+Or add manually to `package.json`:
+
+```json
+"dependencies": {
+  "@activeadmin-plugins/active_admin_sidebar": "2.0.0"
+}
+```
+and execute:
+
+    $ yarn
+
+Add the following line into `app/assets/javascripts/active_admin.js`:
+
+```javascript
+import '@activeadmin-plugins/active_admin_sidebar';
+```
+
+Add the following line into `app/assets/stylesheets/active_admin.scss`:
+
+```css
+@import '@activeadmin-plugins/active_admin_sidebar';
+```
 
 # Configuration per resource
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@activeadmin-plugins/active_admin_sidebar",
+  "version": "2.0.0",
+  "description": "Extension for ActiveAdmin gem to manage sidebar",
+  "main": "src/active_admin_sidebar.js",
+  "style": "src/active_admin_sidebar.scss",
+  "repository": "git@github.com:activeadmin-plugins/active_admin_sidebar.git",
+  "author": "Igor Fedoronchuk <fedoronchuk@gmail.com>",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeadmin-plugins/active_admin_sidebar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/activeadmin-plugins/active_admin_sidebar/issues"
+  },
+  "homepage": "https://github.com/activeadmin-plugins/active_admin_sidebar#readme",
+  "keywords": [
+    "active",
+    "admin",
+    "sidebar"
+  ],
+  "files": [
+    "src/**/*"
+  ],
+  "scripts": {
+    "prepublishOnly": "rm -rf src && cp -R app/assets/javascripts/ src && cp -R app/assets/stylesheets/ src"
+  }
+}


### PR DESCRIPTION
This PR adds support to use this repo as an NPM/Yarn package so we can use it with Webpacker or any other assets bundler.
I implemented this so it uses the same source files as the Rails gem so any change in the JS and CSS is available in both cases. I didn't change the Rails gem-related code this same repo can be used in both ways.

After pack&publish NPM module has minimum files and should look like:
![npm_package](https://user-images.githubusercontent.com/22831505/167447366-625b7d8d-88c9-44a6-884c-998185517d75.png)
